### PR TITLE
Json config and fix py3

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ gpg2 --gen-key
 For info on this step, see the GPG docs for more info:
 http://www.gnupg.org/gph/en/manual.html#AEN26
 
-Tell PassOut about your key:
+Tell PassOut about your key in a JSON config file:
 
 ```
-mkdir ~/.passout && echo -e "gpg=<your_gpg_binary>\nid=<your_gpg_id>\n" > \
-	~/.passout/passoutrc
+mkdir ~/.passout && echo -e \
+    '{"gpg": <your_gpg_binary>, "id": <your_gpg_id>}' > \
+	~/.passout/passout.json
 ```
 
 Where `<your_gpg_binary>` is the path to the gpg binary you want to use (I

--- a/passout/__init__.py
+++ b/passout/__init__.py
@@ -25,6 +25,7 @@ import subprocess
 import collections
 import logging
 import json
+import locale
 from logging import info, debug
 
 VERSION = "0.1"
@@ -161,7 +162,8 @@ def load_clipboard(cfg, pw_name, testing=False):
         except OSError:
             raise PassOutError("call to xclip failed" % cfg["gpg"])
 
-        (out, err) = pipe.communicate(passwd)
+        (out, err) = pipe.communicate(
+            passwd.encode(locale.getpreferredencoding()))
         if pipe.returncode != 0:
             raise PassOutError("xlcip returned non-zero")
 

--- a/passout/__init__.py
+++ b/passout/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2.7
 
-# Copyright (c) 2014, Edd Barrett <vext01@gmail.com>
+# Copyright (c) 2014-2015, Edd Barrett <vext01@gmail.com>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -24,6 +24,7 @@ import getpass
 import subprocess
 import collections
 import logging
+import json
 from logging import info, debug
 
 VERSION = "0.1"
@@ -32,7 +33,7 @@ if not PASSOUT_HOME:
     PASSOUT_HOME = os.path.join(os.environ["HOME"], ".passout")
 
 CRYPTO_DIR = os.path.join(PASSOUT_HOME, "crytpo_store")
-CONFIG_FILE = os.path.join(PASSOUT_HOME, "passoutrc")
+CONFIG_FILE = os.path.join(PASSOUT_HOME, "passout.json")
 
 GROUP_SEP = "__"
 
@@ -124,36 +125,19 @@ def get_config():
     _check_dirs()
 
     # default config
+    # JSON library loads in unicode, so we too use unicode here
     cfg = {
-        "gpg":    "gpg2",
-        "id":     None,
+        u"gpg":    u"gpg2",
+        u"id":     None,
     }
 
     if not os.path.exists(CONFIG_FILE):
         raise PassOutError("Please create the config file '%s'" % CONFIG_FILE)
 
     with open(CONFIG_FILE, "r") as fh:
-        line_no = 0
-        for line in fh:
-            line_no += 1
-            line = line.strip()
-            if line.startswith("#") or line == "":
-                continue
+        new_cfg = json.load(fh)
 
-            elems = line.split("=")
-            if len(elems) != 2:
-                raise PassOutError(
-                    "config file '%s': syntax error on line %d" %
-                    (CONFIG_FILE, line_no)
-                )
-            (key, val) = elems
-
-            if key not in cfg.keys():
-                raise PassOutError(
-                    "config file '%s': unknown key '%s' on line %d" %
-                    (CONFIG_FILE, key, line_no)
-                )
-            cfg[key] = val
+    cfg.update(new_cfg)
 
     if not cfg["id"]:
         raise PassOutError("No 'id' in %s" % CONFIG_FILE)

--- a/passout/passout_cli.py
+++ b/passout/passout_cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2014, Edd Barrett <vext01@gmail.com>
+# Copyright (c) 2014-2015 Edd Barrett <vext01@gmail.com>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -17,6 +17,8 @@
 import __init__ as passout
 import argparse
 import argspander
+import json
+from collections import OrderedDict
 
 
 @argspander.expand
@@ -49,7 +51,10 @@ def cmd_clip(cfg, pass_name):
 
 @argspander.expand
 def cmd_printconfig(cfg):
-    print(cfg)
+    # The json.dumps with sorted keys is a way to work around
+    # Python 3's non-deterministic dictionary ordering.
+    # We need an order for tests.
+    print(json.dumps(cfg, sort_keys=True))
 
 
 @argspander.expand

--- a/passout/passout_cli.py
+++ b/passout/passout_cli.py
@@ -18,7 +18,6 @@ import __init__ as passout
 import argparse
 import argspander
 import json
-from collections import OrderedDict
 
 
 @argspander.expand

--- a/tests/support.py
+++ b/tests/support.py
@@ -22,7 +22,7 @@ GPG_ID = "test@localhost"
 
 SOURCE_DIR = os.path.abspath(os.path.join(TEST_DIR, ".."))
 PASSOUT = os.path.join(SOURCE_DIR, "passout", "passout_cli.py")
-PASSOUT_CONFIG = os.path.join(PASSOUT_DIR, "passoutrc")
+PASSOUT_CONFIG = os.path.join(PASSOUT_DIR, "passout.json")
 
 sys.path.append(os.path.join(TEST_DIR, ".."))
 import passout
@@ -59,7 +59,8 @@ def _make_fresh_passout_dir(gpg):
 
     os.mkdir(PASSOUT_DIR)
     with open(PASSOUT_CONFIG, "w") as config:
-        config.write("id=%s\ngpg=%s\n" % (GPG_ID, gpg))
+        json_s = '{"id": "%s", "gpg": "%s"}' % (GPG_ID, gpg)
+        config.write(json_s)
 
 
 def get_clipboard_text(clipboard):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import os
 
 import pexpect
 import pytest
+import sys
 
 import support
 
@@ -24,7 +25,7 @@ class TestCLI(support.PassOutCliTest):
 
     def test_config(self):
         child1 = self.run_passout("config")
-        child1.expect("{'gpg': '.*?', 'id': '.*?'}")
+        child1.expect('{"gpg": ".*?", "id": ".*?"}')
         child1.expect(pexpect.EOF)
 
     def test_ls(self, rand_pwname, rand_pw):

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -6,6 +6,7 @@ import json
 import support
 import passout
 from passout import PassOutError
+from distutils.spawn import find_executable
 
 
 def dummy_check_dirs():
@@ -52,9 +53,8 @@ class TestLib(support.PassOutLibTest):
         assert got == []
 
     @pytest.mark.skipif(os.environ["DISPLAY"] is None, reason="No X11")
+    @pytest.mark.skipif(find_executable("xclip") is None, reason="No xclip")
     def test_clip(self, cfg, rand_pwname, rand_pw):
-        # XXX skip if xclip not found
-
         passout.add_password(cfg, rand_pwname, rand_pw)
         passout.load_clipboard(cfg, rand_pwname, testing=True)
 


### PR DESCRIPTION
Richard,

Can youhave a quick look at this. 

* Use a JSON config file.
* Fix tests on Python3 (includes a workaround for one issue which is a mystery).

You will need to update your config file, but it is trivial. Something like this in `passout.json` (note new file name also):

```
{                                                                               
    "id": "jim@bob.com",                                               
    "gpg": "/usr/local/bin/gpg2"                                                
}   
```

Once this is in, I will add travis to PRs.